### PR TITLE
[-] bugfix in hookAjaxCall() conditional assignation

### DIFF
--- a/blockcart.php
+++ b/blockcart.php
@@ -208,7 +208,7 @@ class BlockCart extends Module
 		$this->assignContentVars($params);
 		$res = Tools::jsonDecode($this->display(__FILE__, 'blockcart-json.tpl'), true);
 
-		if (is_array($res) && $id_product = Tools::getValue('id_product') && Configuration::get('PS_BLOCK_CART_SHOW_CROSSSELLING'))
+		if (is_array($res) && ($id_product = Tools::getValue('id_product')) && Configuration::get('PS_BLOCK_CART_SHOW_CROSSSELLING'))
 		{
 			$this->smarty->assign('orderProducts', OrderDetail::getCrossSells($id_product, $this->context->language->id,
 				Configuration::get('PS_BLOCK_CART_XSELL_LIMIT')));


### PR DESCRIPTION
hookAjaxCall() is buggy, `$id_product` is not correct because of this part of the condition :
<pre>
$id_product = Tools::getValue('id_product') && Configuration::get('PS_BLOCK_CART_SHOW_CROSSSELLING')
</pre>
so `$id_product` is always equal to `true` and casted to `1` when asking for cross selling products.....