### PR TITLE
Voucher row not displayed correctly in AJAX mode

### DIFF
--- a/blockcart.tpl
+++ b/blockcart.tpl
@@ -117,24 +117,26 @@ var generated_date = {$smarty.now|intval};
 		</dl>
 	{/if}
 		<p {if $products}class="hidden"{/if} id="cart_block_no_products">{l s='No products' mod='blockcart'}</p>
-		{if $discounts|@count > 0}
+
 		<table id="vouchers"{if $discounts|@count == 0} style="display:none;"{/if}>
-			{foreach from=$discounts item=discount}
-				{if $discount.value_real > 0}
-				<tr class="bloc_cart_voucher" id="bloc_cart_voucher_{$discount.id_discount}">
-					<td class="quantity">1x</td>
-					<td class="name" title="{$discount.description}">{$discount.name|truncate:18:'...'|escape:'html':'UTF-8'}</td>
-					<td class="price">-{if $priceDisplay == 1}{convertPrice price=$discount.value_tax_exc}{else}{convertPrice price=$discount.value_real}{/if}</td>
-					<td class="delete">
-						{if strlen($discount.code)}
-							<a class="delete_voucher" href="{$link->getPageLink('$order_process', true)}?deleteDiscount={$discount.id_discount}" title="{l s='Delete' mod='blockcart'}" rel="nofollow"><img src="{$img_dir}icon/delete.gif" alt="{l s='Delete' mod='blockcart'}" class="icon" /></a>
-						{/if}
-					</td>
-				</tr>
-				{/if}
-			{/foreach}					
+			<tbody>
+				{foreach from=$discounts item=discount}
+					{if $discount.value_real > 0}
+					<tr class="bloc_cart_voucher" id="bloc_cart_voucher_{$discount.id_discount}">
+						<td class="quantity">1x</td>
+						<td class="name" title="{$discount.description}">{$discount.name|truncate:18:'...'|escape:'html':'UTF-8'}</td>
+						<td class="price">-{if $priceDisplay == 1}{convertPrice price=$discount.value_tax_exc}{else}{convertPrice price=$discount.value_real}{/if}</td>
+						<td class="delete">
+							{if strlen($discount.code)}
+								<a class="delete_voucher" href="{$link->getPageLink('$order_process', true)}?deleteDiscount={$discount.id_discount}" title="{l s='Delete' mod='blockcart'}" rel="nofollow"><img src="{$img_dir}icon/delete.gif" alt="{l s='Delete' mod='blockcart'}" class="icon" /></a>
+							{/if}
+						</td>
+					</tr>
+					{/if}
+				{/foreach}
+			</tbody>
 		</table>
-		{/if}
+
 		<p id="cart-prices">
 			<span id="cart_block_shipping_cost" class="price ajax_cart_shipping_cost">{$shipping_cost}</span>
 			<span>{l s='Shipping' mod='blockcart'}</span>


### PR DESCRIPTION
When in ajax mode and adding a prod, then the vouchers are not displayed because the vouchers table does not exist and JS does only handle rows of the non-existing table but not create the table itself.
Made that a display:none table with TBODY tag is always existing that can be made visible and filled by JS depending on the product added.